### PR TITLE
Add name attribute to cookbook metadata files

### DIFF
--- a/cookbooks/composer/metadata.rb
+++ b/cookbooks/composer/metadata.rb
@@ -1,3 +1,4 @@
+name             "composer"
 maintainer       "Escape Studios"
 maintainer_email "dev@escapestudios.com"
 license          "MIT"

--- a/cookbooks/pdepend/metadata.rb
+++ b/cookbooks/pdepend/metadata.rb
@@ -1,3 +1,4 @@
+name             "pdepend"
 maintainer       "Escape Studios"
 maintainer_email "dev@escapestudios.com"
 license          "MIT"

--- a/cookbooks/phpcpd/metadata.rb
+++ b/cookbooks/phpcpd/metadata.rb
@@ -1,3 +1,4 @@
+name             "phpcpd"
 maintainer       "Escape Studios"
 maintainer_email "dev@escapestudios.com"
 license          "MIT"

--- a/cookbooks/phploc/metadata.rb
+++ b/cookbooks/phploc/metadata.rb
@@ -1,3 +1,4 @@
+name             "phploc"
 maintainer       "Escape Studios"
 maintainer_email "dev@escapestudios.com"
 license          "MIT"

--- a/cookbooks/phpmd/metadata.rb
+++ b/cookbooks/phpmd/metadata.rb
@@ -1,3 +1,4 @@
+name             "phpmd"
 maintainer       "Escape Studios"
 maintainer_email "dev@escapestudios.com"
 license          "MIT"

--- a/cookbooks/phpunit/metadata.rb
+++ b/cookbooks/phpunit/metadata.rb
@@ -1,3 +1,4 @@
+name             "phpunit"
 maintainer       "Escape Studios"
 maintainer_email "dev@escapestudios.com"
 license          "MIT"


### PR DESCRIPTION
This fixes errors like:

```
==> default: [2015-11-12T22:20:53+00:00] ERROR: Cookbook loaded at path(s) [/tmp/vagrant-chef/07fcd9a9688275ec1e97906b1bb9678e/cookbooks/composer] has invalid metadata: The `name' attribute is required in cookbook metadata
```
